### PR TITLE
speed up CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,14 @@ language: node_js
 node_js:
   - "8.10.0"
 
+
+# this ensures PRs based on a local branch are not built twice
+# the downside is that a PR targeting a different branch is not built
+# but as a workaround you can add the branch to this list
+branches:
+  only:
+    - master
+
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,4 @@ before_script:
     fi
 
 script:
-  - ./script/test && ./script/package
+  - ./script/test


### PR DESCRIPTION
This PR helps speed up the feedback process by:

 - preventing duplicate builds of PRs from local branches
 - skip packaging as part of the CI build