### PR TITLE
some eslint fixups

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,7 @@
         "never"
       ],
       "no-var": "error",
+      "prefer-const": "error",
       "jsx-quotes": [
         "error",
         "prefer-double"

--- a/.eslintrc
+++ b/.eslintrc
@@ -46,7 +46,8 @@
       {
           "files": "*-test.js",
           "rules": {
-              "no-unused-expressions": "off"
+              "no-unused-expressions": "off",
+              "react/jsx-no-bind": "off"
           }
       }
     ]

--- a/app/logger.js
+++ b/app/logger.js
@@ -16,7 +16,7 @@ module.exports = {
     })
 
     // Route incoming "log-entry" messages from 'app/renderer-logger'
-    let self = this
+    const self = this
     ipcMain.on("log-entry", (event, opts) => {
       self.logWithType(opts.type, opts.message)
     })

--- a/app/main.js
+++ b/app/main.js
@@ -29,7 +29,7 @@ function createWindow () {
   }
 
   if (!isDev) {
-    let msBetweenUpdates = 1000 * 60 * 30
+    const msBetweenUpdates = 1000 * 60 * 30
     updater.start(app, msBetweenUpdates, () => {
       mainWindow.webContents.send("info", {msg: "update found"})
     }, (err) => {
@@ -60,19 +60,19 @@ function loadPopulatePage (assignmentURL) {
 
 app.on("open-url", function (event, urlToOpen) {
   event.preventDefault()
-  let urlParams = new URL(urlToOpen).searchParams
-  let isClassroomDeeplink = urlParams.has("assignment_url")
-  let isOAuthDeeplink = urlParams.has("code")
+  const urlParams = new URL(urlToOpen).searchParams
+  const isClassroomDeeplink = urlParams.has("assignment_url")
+  const isOAuthDeeplink = urlParams.has("code")
 
   if (isClassroomDeeplink) {
-    let assignmentURL = urlParams.get("assignment_url")
+    const assignmentURL = urlParams.get("assignment_url")
     if (app.isReady()) {
       loadPopulatePage(assignmentURL)
     } else {
       deepLinkURLOnReady = assignmentURL
     }
   } else if (isOAuthDeeplink) {
-    let oauthCode = urlParams.get("code")
+    const oauthCode = urlParams.get("code")
     fetchAccessToken(oauthCode)
   }
 })

--- a/app/modules/assignment/__tests__/selectors-test.js
+++ b/app/modules/assignment/__tests__/selectors-test.js
@@ -3,30 +3,30 @@ import { expect } from "chai"
 import { all, typeLabel, name, url, error, valid, fetching } from "../selectors"
 
 describe("assignment selectors", () => {
-  let testIndividualAssignment = {
+  const testIndividualAssignment = {
     name: "Assignment 1: Introduction to Programming",
     type: "individual",
     url: "",
     isFetching: false,
   }
 
-  let testGroupAssignment = {
+  const testGroupAssignment = {
     name: "Assignment 1: Introduction to Programming",
     type: "group",
     url: "",
     isFetching: false,
   }
 
-  let testInvalidTypeAssignment = {
+  const testInvalidTypeAssignment = {
     name: "Assignment 1: Introduction to Programming",
     type: "somethingelse"
   }
 
-  let testInvalidNameAssignment = {
+  const testInvalidNameAssignment = {
     type: "individual",
   }
 
-  let testErrorAssignment = {
+  const testErrorAssignment = {
     name: "Assignment 1: Introduction to Programming",
     type: "individual",
     error: "Test Error",

--- a/app/modules/assignment/actions/__tests__/assignment-fetch-info-test.js
+++ b/app/modules/assignment/actions/__tests__/assignment-fetch-info-test.js
@@ -15,7 +15,7 @@ const jsonOK = (body) => {
 }
 
 describe("assignmentFetchInfo", () => {
-  let invalidURLAssignment = {
+  const invalidURLAssignment = {
     name: "Test Assignment",
     type: "individual",
     url: "invalidURL",
@@ -23,7 +23,7 @@ describe("assignmentFetchInfo", () => {
     error: null,
   }
 
-  let validAssignment = {
+  const validAssignment = {
     name: "Test Assignment",
     type: "individual",
     url: "http://classroom.github.com/classrooms/test-org/assignments/test-assignment",
@@ -31,7 +31,7 @@ describe("assignmentFetchInfo", () => {
     error: null,
   }
 
-  let validSettings = {
+  const validSettings = {
     username: "testUser",
   }
 

--- a/app/modules/pagination/__tests__/selectors-test.js
+++ b/app/modules/pagination/__tests__/selectors-test.js
@@ -3,31 +3,31 @@ import { expect } from "chai"
 import { nextPage, outOfDate, fetching } from "../selectors"
 
 describe("pagination selectors", () => {
-  let assignmentURL = "http://classroom.github.com/classrooms/test-org/assignments/test-assignment"
+  const assignmentURL = "http://classroom.github.com/classrooms/test-org/assignments/test-assignment"
 
-  let initialPaginationState = {
+  const initialPaginationState = {
     assignmentURL: "",
     fetching: false,
     nextPage: 1,
     submissionIds: [],
   }
 
-  let paginationWithNext = {
+  const paginationWithNext = {
     assignmentURL: "",
     fetching: true,
     nextPage: 2,
     submissionIds: [1],
   }
 
-  let paginationWithURL = {
+  const paginationWithURL = {
     assignmentURL: assignmentURL,
   }
 
-  let assignmentWithLatestURL = {
+  const assignmentWithLatestURL = {
     url: assignmentURL,
   }
 
-  let assignmentWithDifferentURL = {
+  const assignmentWithDifferentURL = {
     url: "different url"
   }
 

--- a/app/modules/pagination/actions/__tests__/pagination-fetch-all-test.js
+++ b/app/modules/pagination/actions/__tests__/pagination-fetch-all-test.js
@@ -5,7 +5,7 @@ import { fetchAllPages } from "../pagination-fetch-all"
 import { PAGINATION_SET_ASSIGNMENT_URL, PAGINATION_SET_FETCHING } from "../../constants"
 
 describe("paginationFetchAll", () => {
-  let sampleAssignmentURL = "http://classroom.github.com/classrooms/test-org/assignments/test-assignment"
+  const sampleAssignmentURL = "http://classroom.github.com/classrooms/test-org/assignments/test-assignment"
 
   let dispatch, getState
 

--- a/app/modules/pagination/actions/__tests__/pagination-fetch-page-test.js
+++ b/app/modules/pagination/actions/__tests__/pagination-fetch-page-test.js
@@ -23,23 +23,23 @@ const sampleSubmission = (id) => {
 }
 
 describe("paginationFetchPage", () => {
-  let sampleAssignmentURL = "http://classroom.github.com/classrooms/test-org/assignments/test-assignment"
+  const sampleAssignmentURL = "http://classroom.github.com/classrooms/test-org/assignments/test-assignment"
 
   let dispatch, getState
 
-  let defaultHeaders = {
+  const defaultHeaders = {
     "Content-Type": "application/json",
   }
 
-  let middlePageResponseHeaders = {
+  const middlePageResponseHeaders = {
     "Link": LinkHeader.parse("").set({
       rel: "next",
       uri: "sample-next.com?page=2"
     })
   }
 
-  let sampleSubmissionIds = [1, 2]
-  let populatePageResponse = sampleSubmissionIds.map((id) => sampleSubmission(id))
+  const sampleSubmissionIds = [1, 2]
+  const populatePageResponse = sampleSubmissionIds.map((id) => sampleSubmission(id))
 
   beforeEach(() => {
     dispatch = sinon.spy()

--- a/app/modules/pagination/actions/__tests__/pagination-receive-page-test.js
+++ b/app/modules/pagination/actions/__tests__/pagination-receive-page-test.js
@@ -2,7 +2,7 @@ import { expect } from "chai"
 import { paginationReceivePage } from "../pagination-receive-page"
 import { PAGINATION_RECEIVE_PAGE } from "../../constants"
 
-let repos = [
+const repos = [
   {id: 1},
   {id: 2},
 ]

--- a/app/modules/pagination/actions/__tests__/pagination-set-assignment-url-test.js
+++ b/app/modules/pagination/actions/__tests__/pagination-set-assignment-url-test.js
@@ -3,7 +3,7 @@ import { paginationSetAssignmentURL } from "../pagination-set-assignment-url"
 import { PAGINATION_SET_ASSIGNMENT_URL } from "../../constants"
 
 describe("paginationSetAssignmentURL", () => {
-  let assignmentURL = "http://classroom.github.com/classrooms/test-org/assignments/test-assignment"
+  const assignmentURL = "http://classroom.github.com/classrooms/test-org/assignments/test-assignment"
 
   it("creates action with correct type and url", () => {
     expect(paginationSetAssignmentURL(assignmentURL)).eql({

--- a/app/modules/pagination/reducers/__tests__/pagination-test.js
+++ b/app/modules/pagination/reducers/__tests__/pagination-test.js
@@ -5,7 +5,7 @@ import {
   PAGINATION_RESET, PAGINATION_SET_NEXT_PAGE, PAGINATION_RECEIVE_PAGE,
 } from "../../constants"
 
-let assignmentURL = "http://classroom.github.com/classrooms/test-org/assignments/test-assignment"
+const assignmentURL = "http://classroom.github.com/classrooms/test-org/assignments/test-assignment"
 
 const initialPaginationState = {
   assignmentURL: "",

--- a/app/modules/settings/actions/__tests__/settings-logout-user-test.js
+++ b/app/modules/settings/actions/__tests__/settings-logout-user-test.js
@@ -49,7 +49,7 @@ describe("settingsLogoutUser", () => {
   })
 
   it("clears session storage", async () => {
-    let sessionSpy = sinon.spy()
+    const sessionSpy = sinon.spy()
     session.defaultSession.clearStorageData = sessionSpy
     await settingsLogoutUser()(dispatch)
 
@@ -58,7 +58,7 @@ describe("settingsLogoutUser", () => {
 
   // TODO: Make this test more specific after keytar config is finalized
   it("calls node keytar delete password", async () => {
-    let keytarStub = sinon.stub(keytar, "deletePassword")
+    const keytarStub = sinon.stub(keytar, "deletePassword")
     await settingsLogoutUser()(dispatch)
 
     expect(keytarStub.calledOnce).is.true

--- a/app/modules/submissions/__tests__/selectors-test.js
+++ b/app/modules/submissions/__tests__/selectors-test.js
@@ -3,7 +3,7 @@ import { expect } from "chai"
 import { all, num, selected, numSelected, areAllSelected } from "../selectors"
 
 describe("selectors", () => {
-  let evelyn = {
+  const evelyn = {
     id: 1,
     username: "StudentEvelyn",
     displayName: "Evelyn",
@@ -13,7 +13,7 @@ describe("selectors", () => {
     progress: 30
   }
 
-  let max = {
+  const max = {
     id: 2,
     username: "StudentMax",
     displayName: "Max",
@@ -23,7 +23,7 @@ describe("selectors", () => {
     progress: 50
   }
 
-  let ali = {
+  const ali = {
     id: 4,
     username: "StudentAli",
     displayName: "Ali",
@@ -33,8 +33,8 @@ describe("selectors", () => {
     progress: 100
   }
 
-  let mixedList = [evelyn, max]
-  let allSelectedList = [evelyn, ali]
+  const mixedList = [evelyn, max]
+  const allSelectedList = [evelyn, ali]
 
   describe("all", () => {
     it("extracts the submissions object from the state", () => {

--- a/app/modules/submissions/actions/submission-clone-all.js
+++ b/app/modules/submissions/actions/submission-clone-all.js
@@ -8,7 +8,7 @@ const submissionClone = submissionCloneFunc(clone)
 // PUBLIC: Async thunk action for cloning all selected submissions.
 export const submissionCloneAll = () => {
   return (dispatch, getState) => {
-    let selectedSubmissions = selected(getState())
+    const selectedSubmissions = selected(getState())
     return Promise.map(selectedSubmissions, submission => {
       return dispatch(submissionClone(submission))
     },

--- a/app/modules/submissions/reducers/submissions.js
+++ b/app/modules/submissions/reducers/submissions.js
@@ -72,7 +72,7 @@ const submissions = (state, action) => {
   case SUBMISSION_RESET:
     return initialState
   case SUBMISSION_CREATE:
-    let newState = [...state]
+    const newState = [...state]
     action.submissions.map((submission) => {
       newState.push(Object.assign({}, initialSubmissionState, submission))
     })

--- a/app/routes/archive/components/__tests__/ItemArchivePanel-test.js
+++ b/app/routes/archive/components/__tests__/ItemArchivePanel-test.js
@@ -39,7 +39,7 @@ const noProgressProps = {
 
 describe("ItemArchivePanel", () => {
   it("renders an ItemPanel, correctly passing down properties", () => {
-    let wrapper = shallow(<ItemArchivePanel {...progressProps}/>)
+    const wrapper = shallow(<ItemArchivePanel {...progressProps}/>)
 
     const itemPanels = wrapper.find("ItemPanel")
     expect(itemPanels.length).equals(1)
@@ -51,39 +51,39 @@ describe("ItemArchivePanel", () => {
   })
 
   it("renders a progress bar when the progress is between 0 and 100", () => {
-    let wrapper = shallow(<ItemArchivePanel {...progressProps}/>)
+    const wrapper = shallow(<ItemArchivePanel {...progressProps}/>)
     expect(wrapper.find(ProgressBar).length).equals(1)
   })
 
   it("does not render the progress bar when cloning is finished", () => {
-    let wrapper = shallow(<ItemArchivePanel {...completeProps}/>)
+    const wrapper = shallow(<ItemArchivePanel {...completeProps}/>)
     expect(wrapper.find(ProgressBar).length).equals(0)
   })
 
   it("renders a 'view' button when the progress is at 100", () => {
-    let wrapper = shallow(<ItemArchivePanel {...completeProps}/>)
+    const wrapper = shallow(<ItemArchivePanel {...completeProps}/>)
     expect(wrapper.find("button").text().indexOf("View")).does.not.equal(-1)
   })
 
   it("does not render a button when the progress is not 100", () => {
-    let wrapper = shallow(<ItemArchivePanel {...progressProps}/>)
+    const wrapper = shallow(<ItemArchivePanel {...progressProps}/>)
     expect(wrapper.find("button").length).equals(0)
   })
 
   it("calls handler when the 'view' button is pressed", () => {
     let wasCalled = false
 
-    let handler = () => {
+    const handler = () => {
       wasCalled = true
     }
-    let wrapper = shallow(<ItemArchivePanel {...completeProps} onViewClick={handler} />)
+    const wrapper = shallow(<ItemArchivePanel {...completeProps} onViewClick={handler} />)
     wrapper.find("button").simulate("click")
 
     expect(wasCalled).equals(true)
   })
 
   it("renders a spinner when the progress is 0", () => {
-    let wrapper = shallow(<ItemArchivePanel {...noProgressProps}/>)
+    const wrapper = shallow(<ItemArchivePanel {...noProgressProps}/>)
     expect(wrapper.find(RingLoader).length).equals(1)
   })
 })

--- a/app/routes/archive/components/__tests__/ItemArchivePanelList-test.js
+++ b/app/routes/archive/components/__tests__/ItemArchivePanelList-test.js
@@ -6,7 +6,7 @@ import { shallow } from "enzyme"
 import ItemArchivePanelList from "../ItemArchivePanelList"
 import ActionableItemArchivePanel from "../../containers/ActionableItemArchivePanel"
 
-let testProps = {
+const testProps = {
   submissions: [{
     id: 1,
     username: "test username",
@@ -26,7 +26,7 @@ let testProps = {
 
 describe("ItemArchivePanelList", () => {
   it("renders ItemArchivePanel components as children", () => {
-    let wrapper = shallow(<ItemArchivePanelList {...testProps} />)
+    const wrapper = shallow(<ItemArchivePanelList {...testProps} />)
     expect(wrapper.find(ActionableItemArchivePanel).length).to.equal(2)
   })
 })

--- a/app/routes/select/components/__tests__/SelectAllPanel-test.js
+++ b/app/routes/select/components/__tests__/SelectAllPanel-test.js
@@ -7,7 +7,7 @@ import { shallow } from "enzyme"
 import SelectAllPanel from "../SelectAllPanel"
 
 describe("SelectAllPanel", () => {
-  let testProps = {
+  const testProps = {
     selected: 3,
     total: 10,
     selectAll: true
@@ -33,8 +33,8 @@ describe("SelectAllPanel", () => {
   })
 
   it("calls handler function with false when the checkbox is unchecked by user", () => {
-    let handler = sinon.spy()
-    let wrapper = shallow(<SelectAllPanel {...testProps} onSelectAllChange={handler} />)
+    const handler = sinon.spy()
+    const wrapper = shallow(<SelectAllPanel {...testProps} onSelectAllChange={handler} />)
     wrapper.find("input").simulate("change")
 
     expect(handler.callCount).to.equal(1)
@@ -42,14 +42,14 @@ describe("SelectAllPanel", () => {
   })
 
   it("calls handler function with true when the checkbox is checked by user", () => {
-    let testPropsChecked = {
+    const testPropsChecked = {
       selected: 3,
       total: 10,
       selectAll: false
     }
 
-    let handler = sinon.spy()
-    let wrapper = shallow(<SelectAllPanel {...testPropsChecked} onSelectAllChange={handler} />)
+    const handler = sinon.spy()
+    const wrapper = shallow(<SelectAllPanel {...testPropsChecked} onSelectAllChange={handler} />)
     wrapper.find("input").simulate("change")
 
     expect(handler.callCount).to.equal(1)

--- a/app/routes/select/components/__tests__/Submission-test.js
+++ b/app/routes/select/components/__tests__/Submission-test.js
@@ -24,7 +24,7 @@ describe("Submission", () => {
   }
 
   it("renders an ItemPanel, correctly passing down properties", () => {
-    let wrapper = shallow(<Submission {...testProps} />)
+    const wrapper = shallow(<Submission {...testProps} />)
 
     const itemPanels = wrapper.find("ItemPanel")
     expect(itemPanels.length).to.equal(1)
@@ -36,7 +36,7 @@ describe("Submission", () => {
   })
 
   it("renders a checked checkbox when it is selected", () => {
-    let wrapper = shallow(<Submission {...testPropsSelected} />)
+    const wrapper = shallow(<Submission {...testPropsSelected} />)
 
     const input = wrapper.find("input")
 
@@ -46,7 +46,7 @@ describe("Submission", () => {
   })
 
   it("renders an unchecked checkbox when it is not selected", () => {
-    let wrapper = shallow(<Submission {...testProps} />)
+    const wrapper = shallow(<Submission {...testProps} />)
 
     const input = wrapper.find("input")
 
@@ -57,10 +57,10 @@ describe("Submission", () => {
 
   it("calls handler when checkbox is pressed", () => {
     let calledArg = null
-    let clickHandler = (arg) => {
+    const clickHandler = (arg) => {
       calledArg = arg
     }
-    let wrapper = shallow(<Submission {...testProps} onSelectedChange={clickHandler}/>)
+    const wrapper = shallow(<Submission {...testProps} onSelectedChange={clickHandler}/>)
 
     wrapper.find("input").simulate("change")
     expect(calledArg).to.equal(!testProps.selected)

--- a/app/routes/select/components/__tests__/SubmissionList-test.js
+++ b/app/routes/select/components/__tests__/SubmissionList-test.js
@@ -6,7 +6,7 @@ import SubmissionList from "../SubmissionList"
 import SelectableSubmission from "../../containers/SelectableSubmission"
 
 describe("SubmissionList", () => {
-  let testProps = {
+  const testProps = {
     submissions: [{
       id: 1,
       username: "testusername",
@@ -25,7 +25,7 @@ describe("SubmissionList", () => {
   }
 
   it("renders SelectableSubmission components as children", () => {
-    let wrapper = shallow(<SubmissionList {...testProps} />)
+    const wrapper = shallow(<SubmissionList {...testProps} />)
     expect(wrapper.find(SelectableSubmission).length).to.equal(2)
   })
 })

--- a/app/routes/shared/components/NavFooter.jsx
+++ b/app/routes/shared/components/NavFooter.jsx
@@ -22,7 +22,7 @@ const NavFooter = ({
   left,
   right
 }) => {
-  let children = []
+  const children = []
 
   if (left !== undefined) {
     children.push(

--- a/app/routes/shared/components/__tests__/EditItemPanel-test.js
+++ b/app/routes/shared/components/__tests__/EditItemPanel-test.js
@@ -13,18 +13,18 @@ describe("EditItemPanel", () => {
 
   it("calls onEditClick when pencil is clicked", () => {
     let wasCalled = false
-    let clickHandler = () => {
+    const clickHandler = () => {
       wasCalled = true
     }
-    let wrapper = shallow(<EditItemPanel {...staticOptions} onEditClick={clickHandler}/>)
+    const wrapper = shallow(<EditItemPanel {...staticOptions} onEditClick={clickHandler}/>)
 
     wrapper.find("i").simulate("click")
     expect(wasCalled).to.equal(true)
   })
 
   it("renders an ItemPanel, correctly passing down properties", () => {
-    let noop = () => {}
-    let wrapper = shallow(<EditItemPanel {...staticOptions} onEditClick={noop}/>)
+    const noop = () => {}
+    const wrapper = shallow(<EditItemPanel {...staticOptions} onEditClick={noop}/>)
 
     const itemPanels = wrapper.find("ItemPanel")
     expect(itemPanels.length).to.equal(1)

--- a/app/routes/shared/components/__tests__/ItemPanel-test.js
+++ b/app/routes/shared/components/__tests__/ItemPanel-test.js
@@ -7,7 +7,7 @@ import ItemPanel from "../ItemPanel"
 describe("ItemPanel", () => {
   let wrapper
 
-  let testOptions = {
+  const testOptions = {
     imagePath: "/some/path.jpg",
     title: "test title",
     subtitle: "test subtitle"

--- a/app/routes/shared/components/__tests__/NavFooter-test.js
+++ b/app/routes/shared/components/__tests__/NavFooter-test.js
@@ -7,27 +7,27 @@ import NavFooter from "../NavFooter"
 
 describe("NavFooter", () => {
   it("renders no buttons if none are provided", () => {
-    let wrapper = shallow(<NavFooter />)
+    const wrapper = shallow(<NavFooter />)
     expect(wrapper.find(".btn").length).to.equal(0)
   })
 
   it("renders left button if provided", () => {
-    let testProps = {
+    const testProps = {
       left: {
         label: "TestLabel",
         route: "home"
       }
     }
 
-    let link = {
+    const link = {
       pathname: testProps.left.route,
       state: {
         params: testProps.left.params,
       }
     }
 
-    let wrapper = shallow(<NavFooter {...testProps} />)
-    let rendered = wrapper.find("button.btn")
+    const wrapper = shallow(<NavFooter {...testProps} />)
+    const rendered = wrapper.find("button.btn")
 
     expect(rendered.length).to.equal(1)
     expect(rendered.text()).to.equal(testProps.left.label)
@@ -35,22 +35,22 @@ describe("NavFooter", () => {
   })
 
   it("renders right button if provided", () => {
-    let testProps = {
+    const testProps = {
       right: {
         label: "TestLabel",
         route: "home",
       }
     }
 
-    let link = {
+    const link = {
       pathname: testProps.right.route,
       state: {
         params: testProps.right.params,
       }
     }
 
-    let wrapper = shallow(<NavFooter {...testProps} />)
-    let rendered = wrapper.find("button.btn.pull-right")
+    const wrapper = shallow(<NavFooter {...testProps} />)
+    const rendered = wrapper.find("button.btn.pull-right")
 
     expect(rendered.length).to.equal(1)
     expect(rendered.text()).to.equal(testProps.right.label)
@@ -58,7 +58,7 @@ describe("NavFooter", () => {
   })
 
   it("renders both buttons if provided", () => {
-    let testProps = {
+    const testProps = {
       left: {
         label: "TestLabel",
         route: "home",
@@ -69,16 +69,16 @@ describe("NavFooter", () => {
       }
     }
 
-    let link = {
+    const link = {
       pathname: testProps.right.route,
       state: {
         params: testProps.right.params,
       }
     }
 
-    let wrapper = shallow(<NavFooter {...testProps} />)
-    let right = wrapper.find("button.btn.btn-success")
-    let left = wrapper.find("button.btn.btn-danger")
+    const wrapper = shallow(<NavFooter {...testProps} />)
+    const right = wrapper.find("button.btn.btn-success")
+    const left = wrapper.find("button.btn.btn-danger")
 
     expect(left.length).to.equal(1)
     expect(left.text()).to.equal(testProps.left.label)
@@ -90,9 +90,9 @@ describe("NavFooter", () => {
   })
 
   it("passes on click function to button", () => {
-    let onClickFunc = sinon.spy()
+    const onClickFunc = sinon.spy()
 
-    let testProps = {
+    const testProps = {
       right: {
         label: "TestLabel",
         route: "home",
@@ -100,32 +100,32 @@ describe("NavFooter", () => {
       }
     }
 
-    let wrapper = shallow(<NavFooter {...testProps} />)
-    let rendered = wrapper.find("button.btn.pull-right")
+    const wrapper = shallow(<NavFooter {...testProps} />)
+    const rendered = wrapper.find("button.btn.pull-right")
     rendered.simulate("click")
     expect(onClickFunc.callCount).to.equal(1)
   })
 
   it("passes params to router", () => {
-    let params = {
+    const params = {
       data: "test"
     }
-    let testProps = {
+    const testProps = {
       right: {
         label: "TestLabel",
         route: "home",
         params: params
       }
     }
-    let link = {
+    const link = {
       pathname: testProps.right.route,
       state: {
         params: testProps.right.params,
       }
     }
 
-    let wrapper = shallow(<NavFooter {...testProps} />)
-    let right = wrapper.find("button.btn.pull-right")
+    const wrapper = shallow(<NavFooter {...testProps} />)
+    const right = wrapper.find("button.btn.pull-right")
     expect(right.parent().prop("to")).to.eql(link)
   })
 })

--- a/app/userAuthentication.js
+++ b/app/userAuthentication.js
@@ -16,7 +16,7 @@ export function authorizeUser (mainWindowRef) {
 
 export function fetchAccessToken (code) {
   authWindow.destroy()
-  let data = {
+  const data = {
     client_id: clientId,
     client_secret: clientSecret,
     code: code,


### PR DESCRIPTION
 - Enabling `prefer-const` to help reduce unnecessary `let` usage and favour immutability
 - Some tests now trip `react/jsx-no-bind` which ensures functions passed to JSX are bound to `this`, which I've disabled as the tests are only there to ensure the callback was invoked